### PR TITLE
Include return statement for allocated RPC

### DIFF
--- a/nfsv4/client.c
+++ b/nfsv4/client.c
@@ -307,6 +307,7 @@ static void *nfs4_allocate_rpc(void *z)
     rpc r = allocate(c->h, sizeof(struct rpc));
     r->b = freelist_allocate(c->buffers);
     r->ops = allocate_vector(c->h, c->buffersize);
+    return(r);
 }
 
 static void *nfs4_allocate_buffer(void *z)


### PR DESCRIPTION
Resolves segfault when running `shell`

Now leads to `open client fail extra data in response` error instead