### PR TITLE
Prevent discarding beyond bounds of buffer

### DIFF
--- a/nfsv4/test/shell.c
+++ b/nfsv4/test/shell.c
@@ -531,9 +531,9 @@ value dispatch(client c, vector n)
         for (i = 0; c->commands[i].name[0] ; i++ )
             if (strncmp(c->commands[i].name, command->contents, buffer_length(command)) == 0) 
                 return c->commands[i].f(c, n);
+        error("no such command %b\n", command);
     }
-
-    error("no such command %b\n", command);
+    error("no command entered", command);
 }
 
 

--- a/nfsv4/xdr.c
+++ b/nfsv4/xdr.c
@@ -240,7 +240,15 @@ status parse_filehandle(void *z, buffer b)
 status discard_string(buffer b)
 {
     u32 len = read_beu32(b);
+
     b->start += len*4;
+
+    // handle trying to discard beyond the length of the buffer
+    // by discarding only until the end of the buffer
+    if (b->start > b->end) {
+      b->start = b->end;
+    }
+
 }
 
 status read_fs4_status(buffer b)


### PR DESCRIPTION
This brings shell back to a working state.

This does not fix the problem of incorrectly parsing the information in the buffer. I'll document the specific error in an issue. 

Output of the shell `ls`. I've stored two files in EFS.
```
received op: SEQUENCE 35
start decode 0x12d04b0 264
finish 0x12d04b0 228
received op: PUTFH 16
received op: READDIR 1a
start decode 0x12d04b0 212
finish 0x12d04b0 0
-rw-rw-r-- 500 500 45 aeneid.txt
-rw-rw-r-- 500 500 24 test.txt
zig: -2 -2
0.016584003
>
```
