### PR TITLE
Fully parse struct EXCHANGE_ID4resok

### DIFF
--- a/nfsv4/session.c
+++ b/nfsv4/session.c
@@ -29,8 +29,26 @@ status parse_exchange_id(void *z, buffer b)
     //    state_protect4_r eir_state_protect;
     //    server_owner4    eir_server_owner;
     b->start += 12;
-    discard_string(b);     //    opaque           eir_server_scope<NFS4_OPAQUE_LIMIT>;
-    discard_string(b);        //    nfs_impl_id4     eir_server_impl_id<1>;
+
+    //    opaque           eir_server_scope<NFS4_OPAQUE_LIMIT>;
+    discard_string(b);     
+    
+    //    opaque           eir_server_scope<NFS4_OPAQUE_LIMIT>;
+    discard_string(b);        
+    
+    //    nfs_impl_id4     eir_server_impl_id<1>;
+
+    // utf8str_cis   nii_domain;
+    discard_string(b);
+    // utf8str_cs    nii_name;
+    discard_string(b);
+    
+    // nfstime4      nii_date;
+    // int64_t         seconds;
+    u64 seconds = read_beu64(b);
+    // uint32_t        nseconds;
+    u32 nseconds = read_beu32(b);
+
     return NFS4_OK;
 }
 

--- a/nfsv4/session.c
+++ b/nfsv4/session.c
@@ -37,6 +37,7 @@ status parse_exchange_id(void *z, buffer b)
     discard_string(b);        
     
     //    nfs_impl_id4     eir_server_impl_id<1>;
+    u32 eir_server_impl_id_length = read_beu32(b);
 
     // utf8str_cis   nii_domain;
     discard_string(b);

--- a/nfsv4/xdr.c
+++ b/nfsv4/xdr.c
@@ -240,7 +240,7 @@ status parse_filehandle(void *z, buffer b)
 status discard_string(buffer b)
 {
     u32 len = read_beu32(b);
-    b->start += len*4;
+    b->start += len;
 }
 
 status read_fs4_status(buffer b)

--- a/nfsv4/xdr.c
+++ b/nfsv4/xdr.c
@@ -243,9 +243,8 @@ status discard_string(buffer b)
     
     // bytes are followed by enough (0 to 3) residual zero bytes, r, to make 
     // the total byte count a multiple of four.
-    while (len % 4 != 0) {
-      len += 1;
-    }
+    len = (len + 3) & ~0x03;
+
     b->start += len;
 }
 

--- a/nfsv4/xdr.c
+++ b/nfsv4/xdr.c
@@ -240,6 +240,12 @@ status parse_filehandle(void *z, buffer b)
 status discard_string(buffer b)
 {
     u32 len = read_beu32(b);
+    
+    // bytes are followed by enough (0 to 3) residual zero bytes, r, to make 
+    // the total byte count a multiple of four.
+    while (len % 4 != 0) {
+      len += 1;
+    }
     b->start += len;
 }
 


### PR DESCRIPTION
- Fix `discard_string` to discard multiples of 4 bytes
- Parse through the rest of EXCHANGE_ID4resok