### PR TITLE
Prevent attempts to dispatch null command

### DIFF
--- a/nfsv4/test/shell.c
+++ b/nfsv4/test/shell.c
@@ -531,9 +531,9 @@ value dispatch(client c, vector n)
         for (i = 0; c->commands[i].name[0] ; i++ )
             if (strncmp(c->commands[i].name, command->contents, buffer_length(command)) == 0) 
                 return c->commands[i].f(c, n);
+        error("no such command %b\n", command);
     }
-
-    error("no such command %b\n", command);
+    error("no command entered", command);
 }
 
 

--- a/nfsv4/test/shell.c
+++ b/nfsv4/test/shell.c
@@ -533,7 +533,7 @@ value dispatch(client c, vector n)
                 return c->commands[i].f(c, n);
         error("no such command %b\n", command);
     }
-    error("no command entered", command);
+    error("attempted to parse null for command", command);
 }
 
 


### PR DESCRIPTION
When executing `read` without arguments, a segfault occurs as the program tries to parse the next argument that does not exist. This PR adds error statements to catch this case.