### PR TITLE
Send reclaim_complete at end of rpc_connection

### DIFF
--- a/nfsv4/session.c
+++ b/nfsv4/session.c
@@ -195,6 +195,5 @@ status rpc_connection(nfs4 c)
         push_op(r, OP_GETFH, parse_filehandle, c->root_filehandle);
         check(transact(r));
     }
-    return NFS4_OK;
-    // return reclaim_complete(c);
+    return reclaim_complete(c);
 }


### PR DESCRIPTION
- Resolve the grace error that occurred after attempting to `create` a new file
- Reverts the change of [this commit](https://github.com/jssmith/ssqlite/commit/aaafdcf996657a2ecb7d73012ea97f3981a67897)