### PR TITLE
try to find out why nfs4_open() doesn't return the proper error code

### DIFF
--- a/test/pysfs.c
+++ b/test/pysfs.c
@@ -35,7 +35,9 @@ PyObject *open_file_py(const char* file_name, const char* mode) {
     int flags = file_open_mode(mode);
 
     nfs4_file f = malloc(sizeof(struct nfs4_file));
-    if (nfs4_open(client, file_name, flags, &p, &f) != NFS4_OK) {
+    int error_code;
+    if ((error_code = nfs4_open(client, file_name, flags, &p, &f)) != NFS4_OK) {
+        printf("Error code: %d\n", error_code);
         printf("Failed to open %s:%s\n", file_name, nfs4_error_string(client));
         exit(1);
     }

--- a/test/pysfs.c
+++ b/test/pysfs.c
@@ -35,8 +35,9 @@ PyObject *open_file_py(const char* file_name, const char* mode) {
     int flags = file_open_mode(mode);
 
     nfs4_file f = malloc(sizeof(struct nfs4_file));
-    if (nfs4_open(client, file_name, flags, &p, &f) != NFS4_OK) {
-        printf("Failed to open %s:%s\n", file_name, nfs4_error_string(client));
+    int error_code;
+    if ((error_code = nfs4_open(client, file_name, flags, &p, &f)) != NFS4_OK) {
+        printf("Failed to open %s: %s\n", file_name, nfs4_error_string(client));
         exit(1);
     }
     assert(f != NULL);
@@ -75,7 +76,7 @@ int file_open_mode(const char *mode) {
                 break;
             case 'w': // open for writing, truncating the file first if it already exists
                 flags |= (NFS4_TRUNC | NFS4_WRONLY | NFS4_CREAT);
-                break 
+                break; 
             case 'a': // open for writing, appending if it exits
                 flags |= (NFS4_WRONLY | NFS4_CREAT);
                 break;
@@ -86,8 +87,6 @@ int file_open_mode(const char *mode) {
             case 't':
                 break;
             case '+':
-                break;
-            case 'U':
                 break;
         }
         ptr++;

--- a/test/pysfs.c
+++ b/test/pysfs.c
@@ -37,6 +37,10 @@ PyObject *open_file_py(const char* file_name, const char* mode) {
     nfs4_file f = malloc(sizeof(struct nfs4_file));
     int error_code;
     if ((error_code = nfs4_open(client, file_name, flags, &p, &f)) != NFS4_OK) {
+        if (error_code == -NFS4_ENOENT) {
+            PyErr_SetString(PyExc_FileNotFoundError, "File does not exist");
+            return (PyObject *) NULL; 
+        }
         printf("Failed to open %s: %s\n", file_name, nfs4_error_string(client));
         exit(1);
     }

--- a/test/sfs.py
+++ b/test/sfs.py
@@ -14,6 +14,7 @@ def mount(host_ip):
     c_helper.create_client_py(b_host_ip)
 
 def open(file_name, mode='r'):
+    #TODO: needs to validate MODE
     fp = c_helper.open_file_py(file_name.encode('utf-8'), mode.encode('utf-8'))
     return FileObjectWrapper(fp)
 

--- a/test/sfs_test.py
+++ b/test/sfs_test.py
@@ -16,9 +16,10 @@ class TestOpen(unittest.TestCase):
         self.assertRaises(FileNotFoundError, sfs.open(filename, 'r')) # error on non-exist file
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Testing of SFS open with Python')
-    parser.add_argument('--mount-point', type=str, required=True, help='Hostname or IP address of EFS mount point')
+    parser.add_argument('--mount-point', type=str, required=True,
+        help='Hostname or IP address of EFS mount point')
     args = parser.parse_args()
     sfs.mount(args.mount_point)
     unittest.main()

--- a/test/sfs_test.py
+++ b/test/sfs_test.py
@@ -1,0 +1,24 @@
+import sfs
+import unittest
+import string
+import random
+import os
+import argparse
+
+class TestOpen(unittest.TestCase):
+    def test_read_mode(self):
+        #'r' open for reading (default)
+        # can read, unable to write, error on file does not exist, 
+        # error on missing read permission (including directory tree)
+
+        # 1. generate a 15-character-long string as filename, chance that it exists is almost zero
+        filename = '/'+''.join(random.choices(string.ascii_uppercase + string.digits, k=15))
+        self.assertRaises(FileNotFoundError, sfs.open(filename, 'r')) # error on non-exist file
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Testing of SFS open with Python')
+    parser.add_argument('--mount-point', type=str, required=True, help='Hostname or IP address of EFS mount point')
+    args = parser.parse_args()
+    sfs.mount(args.mount_point)
+    unittest.main()

--- a/test/sfs_test.py
+++ b/test/sfs_test.py
@@ -3,7 +3,7 @@ import unittest
 import string
 import random
 import os
-import argparse
+import sys
 
 class TestOpen(unittest.TestCase):
     def test_read_mode(self):
@@ -12,14 +12,16 @@ class TestOpen(unittest.TestCase):
         # error on missing read permission (including directory tree)
 
         # 1. generate a 15-character-long string as filename, chance that it exists is almost zero
-        filename = '/'+''.join(random.choices(string.ascii_uppercase + string.digits, k=15))
-        self.assertRaises(FileNotFoundError, sfs.open(filename, 'r')) # error on non-exist file
+         filename = '/'+''.join(random.choices(string.ascii_uppercase + string.digits, k=15))
+        #self.assertRaises(FileNotFoundError, sfs.open(filename, "r")) # error on non-exist file
+        f = sfs.open(filename, "r")
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Testing of SFS open with Python')
-    parser.add_argument('--mount-point', type=str, required=True,
-        help='Hostname or IP address of EFS mount point')
-    args = parser.parse_args()
-    sfs.mount(args.mount_point)
+    #parser = argparse.ArgumentParser(description='Testing of SFS open with Python')
+    #parser.add_argument('--mount-point', type=str, required=True,
+    #   help='Hostname or IP address of EFS mount point')
+    #args = parser.parse_args()
+    #sfs.mount(args.mount_point)
+    sfs.mount(sys.argv.pop())
     unittest.main()

--- a/test/sfs_test.py
+++ b/test/sfs_test.py
@@ -3,6 +3,7 @@ import unittest
 import string
 import random
 import os
+import io
 import sys
 
 class TestOpen(unittest.TestCase):
@@ -11,11 +12,17 @@ class TestOpen(unittest.TestCase):
         # can read, unable to write, error on file does not exist, 
         # error on missing read permission (including directory tree)
 
-        # 1. generate a 15-character-long string as filename, chance that it exists is almost zero
-         filename = '/'+''.join(random.choices(string.ascii_uppercase + string.digits, k=15))
-        #self.assertRaises(FileNotFoundError, sfs.open(filename, "r")) # error on non-exist file
-        f = sfs.open(filename, "r")
+        # 1. generate a 15-character-long string as filename, chance that it exists is close to zero
+        filename = '/'+''.join(random.choices(string.ascii_uppercase + string.digits, k=15))
+        self.assertRaises(FileNotFoundError, sfs.open, filename, "r") # error on non-exist file
+        #f = sfs.open(filename, "r")
+        
+        # 2. check if can read, make you have file 'haha.txt' in your /efs/
+        f = sfs.open('haha.txt', 'r')
+        self.assertEqual(f.read(20), "this is a test file")
 
+        # 3. check if cannot write
+        self.assertRaises(io.UnsupportedOperation, f.write, "1")
 
 if __name__ == '__main__':
     #parser = argparse.ArgumentParser(description='Testing of SFS open with Python')


### PR DESCRIPTION
1. addressed the issue that the old `open_file_py()` in pysfs.c will always create a file and set its permission to read&write despite of what the specified mode says. 
2. It looks like `nfs4_open()` should return `NFS4_ENOENT`(not very sure, I could be wrong) which is -2 when trying to open a nonexistent file, instead it returns 2. So need to figure out how to get the correct error code, then python wrapper can throw the corresponding excpetion