### PR TITLE
Implemented NFS4_TRUNC in client.c. Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ Building and Running NFSv4 Benchmark
 
 `./nfsv4_read_write_test read /some_file_name` to run read benchmark
 
-## Run the Python Benchmarks
+Ensure you have Python 3.x installed for instructions below
 
-Ensure you have Python 3.x installed
+## Run the Python Benchmarks
 
 `python3 python_simply_demo.py --mount-point=${NFS_SERVER} --test-file=/some_file_name`
 
 `python3 benchmark.py --mount-point=${NFS_SERVER} --test-file=/some_file_name`
 
-## Run SFS Python Tests
+## Run the SFS Python Tests
 
 `sudo python3 sfs_test.py ${NFS4_SERVER}`

--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ Building and Running NFSv4 Benchmark
 
 `./nfsv4_read_write_test read /some_file_name` to run read benchmark
 
-## Build the Python Benchmarks
-
-1. Ensure you have Python 3.x installed.
-
-2. In `/test` run `make pysfs.so`
-
 ## Run the Python Benchmarks
+
+Ensure you have Python 3.x installed
 
 `python3 python_simply_demo.py --mount-point=${NFS_SERVER} --test-file=/some_file_name`
 
 `python3 benchmark.py --mount-point=${NFS_SERVER} --test-file=/some_file_name`
+
+## Run SFS Python Tests
+
+`sudo python3 sfs_test.py ${NFS4_SERVER}`

--- a/nfsv4/client.c
+++ b/nfsv4/client.c
@@ -138,19 +138,19 @@ int nfs4_open(nfs4 c, char *path, int flags, nfs4_properties p, nfs4_file *dest)
     push_open(r, final, flags, f, p);
     push_op(r, OP_GETFH, parse_filehandle, f->filehandle);
     push_op(r, OP_GETATTR, get_expected_size, f);
+
+    push_fattr_mask(r, NFS4_PROP_SIZE);
+    *dest = f;
+    int status = api_check(c, transact(r));
     // force write for trunc
-    if (flags & NFS4_TRUNC) {
-        api_check(c, transact(r));
+    if (status == NFS4_OK && (flags & NFS4_TRUNC)) {
         struct nfs4_properties t;
         t.mask = NFS4_PROP_SIZE;
         t.size = 0;
         f->expected_size = 0;
-        return nfs4_change_properties(f, &t);
-    } else {
-        push_fattr_mask(r, NFS4_PROP_SIZE);
-        *dest = f;
-        return api_check(c, transact(r));
-    }
+        nfs4_change_properties(f, &t); // nfs4_change_properties seems to be buggy
+    } 
+    return status;
 }
 
 int nfs4_close(nfs4_file f)

--- a/nfsv4/client.c
+++ b/nfsv4/client.c
@@ -141,16 +141,16 @@ int nfs4_open(nfs4 c, char *path, int flags, nfs4_properties p, nfs4_file *dest)
 
     push_fattr_mask(r, NFS4_PROP_SIZE);
     *dest = f;
-    int status = api_check(c, transact(r));
+    int nfs4_status = api_check(c, transact(r));
     // force write for trunc
-    if (status == NFS4_OK && (flags & NFS4_TRUNC)) {
-        struct nfs4_properties t;
-        t.mask = NFS4_PROP_SIZE;
-        t.size = 0;
+    if (nfs4_status == NFS4_OK && (flags & NFS4_TRUNC)) {
+        //struct nfs4_properties t;
+        p->mask = NFS4_PROP_SIZE;
+        p->size = 0;
         f->expected_size = 0;
-        nfs4_change_properties(f, &t); // nfs4_change_properties seems to be buggy
+        nfs4_change_properties(f, p); // nfs4_change_properties seems to be buggy
     } 
-    return status;
+    return nfs4_status;
 }
 
 int nfs4_close(nfs4_file f)

--- a/test/sfs.py
+++ b/test/sfs.py
@@ -66,7 +66,7 @@ def open(file_name, mode='r'):
         if c == 'r':
             flags |= NFS4_RDONLY
         elif c == 'w':
-            flags |= (NFS4_TRUNC | NFS4_WRONLY | NFS4_CREAT) # TODO: NFS4_TRUNC cause XDR decode failed when used in open
+            flags |= (NFS4_TRUNC | NFS4_WRONLY | NFS4_CREAT)
         elif c == 'a':
             flags |= (NFS4_WRONLY | NFS4_CREAT)
         else:

--- a/test/sfs.py
+++ b/test/sfs.py
@@ -66,7 +66,7 @@ def open(file_name, mode='r'):
         if c == 'r':
             flags |= NFS4_RDONLY
         elif c == 'w':
-            flags |= (NFS4_TRUNC | NFS4_WRONLY | NFS4_CREAT)
+            flags |= (NFS4_TRUNC | NFS4_WRONLY | NFS4_CREAT) # TODO: NFS4_TRUNC cause XDR decode failed when used in open
         elif c == 'a':
             flags |= (NFS4_WRONLY | NFS4_CREAT)
         else:

--- a/test/sfs_test.py
+++ b/test/sfs_test.py
@@ -59,7 +59,8 @@ class TestOpen(unittest.TestCase):
         new_f = open('/efs/test.txt', 'w+')
         new_f.write('You cannot read it')
         new_f.close()
-        self.assertRaises(io.UnsupportedOperation, sfs.open, '/test.txt', 'w')
+        f = sfs.open('/test.txt', 'w')
+        self.assertRaises(io.UnsupportedOperation, f.read, 1)
 
         # 3. write to an empty file.
         new_f = open('/efs'+filename, 'w+') # this line truncates the file, makes it empty

--- a/test/sfs_test.py
+++ b/test/sfs_test.py
@@ -52,7 +52,7 @@ class TestOpen(unittest.TestCase):
         # chance that it already exists is close to zero.
         random.seed(8) # I also like 8
         filename = '/'+''.join(random.choices(string.ascii_letters + string.digits, k=15))
-        f = sfs.open(filename, 'w') 
+        f = sfs.open(filename, 'w')
         self.assertTrue(os.path.isfile('/efs'+filename))
 
         # 2. check if write-only

--- a/test/sfs_test.py
+++ b/test/sfs_test.py
@@ -18,6 +18,7 @@ class TestOpen(unittest.TestCase):
         # generate a 15-character-long letters-digits-mixed string as filename, 
         # chance that it already exists is close to zero.
         # Open a file with such filename should raise a FileNotFoundError exception
+        random.seed(6) # I like 6
         filename = '/'+''.join(random.choices(string.ascii_letters + string.digits, k=15))
         self.assertRaises(FileNotFoundError, sfs.open, filename, "r") 
         
@@ -49,8 +50,9 @@ class TestOpen(unittest.TestCase):
         # 1. check if opening a non-existing file will first create a such file
         # generate a 15-character-long letters-digits-mixed string as filename, 
         # chance that it already exists is close to zero.
+        random.seed(8) # I also like 8
         filename = '/'+''.join(random.choices(string.ascii_letters + string.digits, k=15))
-        f = sfs.open(filename, 'w')
+        f = sfs.open(filename, 'w') 
         self.assertTrue(os.path.isfile('/efs'+filename))
 
         # 2. check if write-only


### PR DESCRIPTION
1. Calling `nfs4_change_properties()` to truncate a file currently has some side effect that requires further investigation. I suspect `nfs4_change_properties()` is buggy.
2. `WRONLY` flag doesn't work currently. One can still read from a file opened with `WRONLY` flag