### PR TITLE
Adjust nfs4_pwrite and nfs4_pread behavior to be more like C

### DIFF
--- a/nfsv4/client.c
+++ b/nfsv4/client.c
@@ -85,6 +85,7 @@ int nfs4_pwrite(nfs4_file f, void *source, bytes offset, bytes length)
             if (nfs4_is_error(s)) {
                 if (total == 0) {
                     r->c->error_string = s->description;
+                    r->c->error_num = s->error;
                     return -1;
                 } else {
                     return total;

--- a/nfsv4/client.c
+++ b/nfsv4/client.c
@@ -36,7 +36,7 @@ int nfs4_pread(nfs4_file f, void *dest, bytes offset, bytes len)
         rpc r = file_rpc(f);
         u64 transferred = push_read(r, offset,  dest + total, len - total, &f->latest_sid);
         status s;
-        if (total < len) {
+        if (total + transferred < len) {
             // reestablish connection here
             s = rpc_send(r);
         } else {

--- a/nfsv4/nfs4_internal.h
+++ b/nfsv4/nfs4_internal.h
@@ -47,6 +47,7 @@ struct nfs4 {
     u32 maxreqs;
     buffer hostname;
     vector outstanding; // should be a map
+    int error_num;
     buffer error_string;
     buffer root_filehandle;
     struct nfs4_properties default_properties;

--- a/nfsv4/nfs4_internal.h
+++ b/nfsv4/nfs4_internal.h
@@ -47,7 +47,7 @@ struct nfs4 {
     u32 maxreqs;
     buffer hostname;
     vector outstanding; // should be a map
-    int error_num;
+    int nfs_error_num;
     buffer error_string;
     buffer root_filehandle;
     struct nfs4_properties default_properties;

--- a/nfsv4/test/README.md
+++ b/nfsv4/test/README.md
@@ -1,35 +1,58 @@
 # Shell
 A client to interact with the NFS4 protocol
 
+## Example Shell Usage
+
+After ensuring all necessary environment variables are set, run `shell`. 
+We've mounted NFS at `/efs/` and stored `aeneid.txt` at `/efs/aeneid.txt`.   
+
+Opening a file
+
+    > open /aeneid.txt
+    0.002389004
+
+Reading a file. 1024 is the length of `aeneid.txt`.
+
+    > read open /aeneid.txt 
+    [1024]
+    0.003774003
+
+Writing a file currently segfaults.
+
+    > write open /aeneid.txt
+    [SEGFAULT]
+
 ## Commands
-`create` - creates an empty file in reference to the current directory
-`write`
-`append`
-`awrite`
-`read`
-`md5`
-`rm` - removes the file
-`generate`
-`ls` - displays the contents of the current directory
-`cd` - not implemented
-`open` 
-`chmod`
-`chown`
-`conn`
-`local`
-`config`
-`compare`
-`lock`
-`truncate`
-`unlock`
-`mkdir` - make a directory 
+
+- `create` - creates an empty file in reference to the current directory
+- `write`
+- `append`
+- `awrite`
+- `read`
+- `md5`
+- `rm` - removes the file
+- `generate`
+- `ls` - displays the contents of the current directory
+- `cd` - not implemented
+- `open` 
+- `chmod`
+- `chown`
+- `conn`
+- `local`
+- `config`
+- `compare`
+- `lock`
+- `truncate`
+- `unlock`
+- `mkdir` - make a directory 
 
 ## Environment Flags
-`NFS4_SERVER` - the address of the NFS server to connect to
-`NFS_TRACE`
-`NFS_USE_ROOTFH`
-`NFS_USE_PUTROOTFH`
-`NFS_IGNORE_SIGPIPE`
-`NFS_AUTH_NULL`
-`NFS_PACKET_TRACE`
-`NFS_TCP_NODELAY`
+
+- `NFS4_SERVER` - the address of the NFS server to connect to
+- `NFS_TRACE`
+- `NFS_USE_ROOTFH`
+- `NFS_USE_PUTROOTFH`
+- `NFS_IGNORE_SIGPIPE`
+- `NFS_AUTH_NULL`
+- `NFS_PACKET_TRACE`
+- `NFS_TCP_NODELAY`

--- a/nfsv4/test/README.md
+++ b/nfsv4/test/README.md
@@ -2,14 +2,19 @@
 A client to interact with the NFS4 protocol
 
 ## Commands
+
+Each command takes zero or more arguments and return a value. Values can be a PATH, FILE, ERROR, or BUFFER. Each command is evaluated with the rest of the line as arguments. Thus the last command is evaluated first.
+
+For example, `write open /sample.txt generate 2` can be thought of as `write(open(/sample.txt), generate(2))`.
+
 `create` - creates an empty file in reference to the current directory
-`write`
+`write` - create a FILE at the given PATH with given BUFFER `write open /sample.txt generate 2`
 `append`
 `awrite`
 `read`
 `md5`
 `rm` - removes the file
-`generate`
+`generate` - return a BUFFER with randomly generated content - `generate 2`
 `ls` - displays the contents of the current directory
 `cd` - not implemented
 `open` 

--- a/nfsv4/test/README.md
+++ b/nfsv4/test/README.md
@@ -21,7 +21,7 @@ Reading a file.
 Writing a file with two bytes of random content.
 
     > write open /aeneid.txt generate 2
-    [SEGFAULT]
+    0.027
 
 ## Commands
 
@@ -52,7 +52,6 @@ For example, `write open /sample.txt generate 2` can be thought of as `write(ope
 `truncate`
 `unlock`
 `mkdir` - make a directory 
->>>>>>> shell
 
 ## Environment Flags
 

--- a/nfsv4/test/shell.c
+++ b/nfsv4/test/shell.c
@@ -84,6 +84,10 @@ char *server; // support multiple servers
 
 value dispatch(client c, vector n);
 
+// Execute the commmand in __n, // check the result's type tag,
+// and return the result.
+//
+// There are four possible tags or types.
 #define dispatch_tag(__c, __tag, __n)\
 ({\
     void *x = dispatch(__c, __n);\
@@ -104,7 +108,7 @@ char *terminate(buffer b)
 
 buffer pop_path(vector v)
 {
-    buffer n = vector_pop(v);
+    buffer n = fifo_pop(v);
     if (n == 0) error("command requires integer argument");
     return n;
 }
@@ -166,7 +170,7 @@ static value generate(client v, vector args)
 {
     u32 seed = 0;
     u64 len = pop_integer_argument(args);
-    buffer result = allocate_buffer(0, len);
+    buffer result = allocate_buffer(h, len);
     
     for (int i = 0; i < len; i++) {
         seed = (seed * 1103515245 + 12345) & ((1U << 31) - 1);
@@ -254,6 +258,7 @@ static value open_command(client c, vector args)
 
 static value read_command(client c, vector args)
 {
+    // The file read is the result of executing further arguments
     nfs4_file f = dispatch_tag(c, FILE_TAG, args);
     struct nfs4_properties n;
     ncheck(c, nfs4_fstat(f, &n));
@@ -525,6 +530,8 @@ static value help(client c, vector args)
     return 0;
 }
 
+// Identify which function command refers to and 
+// return the result of its execution.
 value dispatch(client c, vector n)
 {
     int i;
@@ -532,6 +539,8 @@ value dispatch(client c, vector n)
     if (!c) return TAG("no session, set NFS4_SERVER environment or use explcit connect command", ERROR_TAG);
     if (command) {
         for (i = 0; c->commands[i].name[0] ; i++ )
+            // Compare the command with the name of each command in the list 
+            // See 45 lines above in nfs_commands
             if (strncmp(c->commands[i].name, command->contents, buffer_length(command)) == 0) 
                 return c->commands[i].f(c, n);
     }
@@ -555,7 +564,8 @@ void print_value(value v)
         return;
         
     case BUFFER_TAG:
-        printf ("[%lld]\n", buffer_length(valueof(v)));
+        printf ("%lld bytes:\n", buffer_length(valueof(v)));
+        printf ("'%s'\n", ((buffer) valueof(v))->contents);
         return;
 
     default:

--- a/nfsv4/test/shell.c
+++ b/nfsv4/test/shell.c
@@ -283,7 +283,7 @@ static value read_command(client c, vector args)
     buffer b = allocate_buffer(h, n.size);
 
     value result = full_read_write(nfs4_pread, f, b, n.size, c);
-    if (*((int *) result) != 0) {
+    if ((int) result != 0) {
       return result;
     }  
 

--- a/nfsv4/test/shell.c
+++ b/nfsv4/test/shell.c
@@ -168,7 +168,7 @@ static value compare(client c, vector args)
 // optional seed
 static value generate(client v, vector args)
 {
-    u32 seed = 0;
+    u32 seed = 24601;
     u64 len = pop_integer_argument(args);
     buffer result = allocate_buffer(h, len);
     

--- a/sqllite_nfs4/sqllite_nfs4.c
+++ b/sqllite_nfs4/sqllite_nfs4.c
@@ -63,16 +63,7 @@ static int nfs4Read(sqlite3_file *pFile,
     while (total_bytes_read < iAmt) {
         int bytes_read = nfs4_pread(f->f, zBuf, iOfst, remaining);
         if (bytes_read < 0) {
-            if (f->ad->trace) {
-                eprintf ("status %s\n", nfs4_error_string(f->ad->c));
-            }
-            switch(f->f->c->error_num) {
-                case NFS4_EBUSY: return SQLITE_BUSY;
-                case NFS4_ETXTBSY: return SQLITE_LOCKED;
-                case NFS4_ENOMEM: return SQLITE_NOMEM;
-                case NFS4_EROFS: return SQLITE_READONLY;
-                default:  return SQLITE_ERROR;
-            }
+            return translate_status(f->ad, f->f->c->error_num);
         }
         total_bytes_read += bytes_read;
         iOfst += bytes_read;
@@ -95,16 +86,7 @@ static int nfs4Write(sqlite3_file *pFile,
     while (total_bytes_written < iAmt) {
         int bytes_written = nfs4_pwrite(f->f, (void *)z, iOfst, remaining);
         if (bytes_written < 0) {
-            if (f->ad->trace) {
-                eprintf ("status %s\n", nfs4_error_string(f->ad->c));
-            }
-            switch(f->f->c->error_num) {
-                case NFS4_EBUSY: return SQLITE_BUSY;
-                case NFS4_ETXTBSY: return SQLITE_LOCKED;
-                case NFS4_ENOMEM: return SQLITE_NOMEM;
-                case NFS5_EROFS: return SQLITE_READONLY;
-                default:  return SQLITE_ERROR;
-            }
+            return translate_status(f->ad, f->f->c->error_num);
         }
         total_bytes_written += bytes_written;
         iOfst += bytes_written;
@@ -459,16 +441,7 @@ static int nfs4Fetch(sqlite3_file *pFile,  sqlite3_int64 iOfst, int iAmt, void *
     while (total_bytes_read < iAmt) {
         int bytes_read = nfs4_pread(f->f, *pp, iOfst, iAmt);
         if (bytes_read < 0) {
-            if (f->ad->trace) {
-                eprintf ("status %s\n", nfs4_error_string(f->ad->c));
-            }
-            switch(f->f->c->error_num) {
-                case NFS4_EBUSY: return SQLITE_BUSY;
-                case NFS4_ETXTBSY: return SQLITE_LOCKED;
-                case NFS4_ENOMEM: return SQLITE_NOMEM;
-                case NFS4_EROFS: return SQLITE_READONLY;
-                default:  return SQLITE_ERROR;
-            }
+            return translate_status(f->ad, f->f->c->error_num);
         }
         total_bytes_read += bytes_read;
         iOfst += bytes_read;

--- a/test/nfsv4_read_write_test.c
+++ b/test/nfsv4_read_write_test.c
@@ -116,8 +116,8 @@ void test_sequential_read(nfs4 client, char* filename, u_int64_t num_blocks, u_i
   for (int bytes_traversed = 0; 
        bytes_traversed < block_size * num_blocks; 
        bytes_traversed += block_size) {
-    int read_status = nfs4_pread(f, read_dst, bytes_traversed, block_size);
-    if (read_status != NFS4_OK) { 
+    int bytes_read = nfs4_pread(f, read_dst, bytes_traversed, block_size);
+    if (bytes_read < block_size) { 
       printf("Failed to read %s:%s\n", filename, nfs4_error_string(client));
       exit(1);
     } 

--- a/test/nfsv4_read_write_test.c
+++ b/test/nfsv4_read_write_test.c
@@ -90,8 +90,8 @@ void test_sequential_write(nfs4 client, char* filename, u_int64_t num_blocks, u_
   for (int bytes_traversed = 0; 
        bytes_traversed < block_size * num_blocks;
        bytes_traversed += block_size) {
-    int write_status = nfs4_pwrite(f, (void*) block_content, bytes_traversed, block_size);
-    if (write_status != NFS4_OK) { 
+    int write_amount = nfs4_pwrite(f, (void*) block_content, bytes_traversed, block_size);
+    if (write_amount < block_size) { 
       printf("Failed to write to %s:%s\n", filename, nfs4_error_string(client));
       exit(1);
     }
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
   if (strcmp("read", operation) == 0) {
     test = test_sequential_read;
   } else if(strcmp("write", operation) == 0) {
-    test = test_sequential_write;;
+    test = test_sequential_write;
   } else {
     usage();
     exit(1);

--- a/test/sfs.py
+++ b/test/sfs.py
@@ -117,12 +117,11 @@ class FileObjectWrapper:
         return buffer.value
 
     def write(self, content_bytes):
-        content_len = len(content_bytes)
-        write_status = c_helper.nfs4_pwrite(self._file, content_bytes, self._pos, content_len)
-        if write_status != NFS4_OK:
-            if write_status == NFS4ERR_OPENMODE:
-                raise io.UnsupportedOperation("not writable") 
+        bytes_written = c_helper.nfs4_pwrite(self._file, content_bytes, self._pos, len(content_bytes))
+        if bytes_written < 0:
+            # if write_status == NFS4ERR_OPENMODE:
+            #    raise io.UnsupportedOperation("not writable") 
             print("Failed to write: ", c_helper.nfs4_error_string(client).decode(encoding='utf-8'))
-            return
-        self._pos += content_len
-        return content_len
+            return -1
+        self._pos += bytes_written
+        return bytes_written

--- a/test/sfs.py
+++ b/test/sfs.py
@@ -107,13 +107,13 @@ class FileObjectWrapper:
 
     def read(self, size=-1):
         buffer = ctypes.create_string_buffer(size)
-        read_status = c_helper.nfs4_pread(self._file, buffer, self._pos, size)
-        if read_status != NFS4_OK:
-            if read_status == NFS4ERR_OPENMODE:
-                raise io.UnsupportedOperation("not readable") 
+        bytes_read = c_helper.nfs4_pread(self._file, buffer, self._pos, size)
+        if bytes_read < 0:
+            # if read_status == NFS4ERR_OPENMODE:
+            #    raise io.UnsupportedOperation("not readable") 
             print("Failed to read file: " + c_helper.nfs4_error_string(client).decode(encoding='utf-8'))
             return
-        self._pos += size
+        self._pos += bytes_read
         return buffer.value
 
     def write(self, content_bytes):


### PR DESCRIPTION
- Implement `nfs4_pwrite` to return bytes written, else -1 upon error
- `struct nfs4` modified to hold the `error_num` in addition to `error_string`, as the error number was previously given thru `pwrite`'s return value
- `sqllite_nfs4/sqllite_nfs4.c` has yet to be compile checked