### PR TITLE
Return bytes sent not bytes requested upon read

### DIFF
--- a/nfsv4/nfs4_internal.h
+++ b/nfsv4/nfs4_internal.h
@@ -68,6 +68,12 @@ struct nfs4_file {
     u64 expected_size;
 };
 
+struct nfs4_read_data {
+    u32 eof;
+    u32 len;
+    void *dest;
+};
+
 struct nfs4_dir {
     struct nfs4_file f;
     u64 cookie;

--- a/nfsv4/transfer.c
+++ b/nfsv4/transfer.c
@@ -8,7 +8,12 @@ status finish_read(void *dest, buffer b)
 {
     u32 eof = read_beu32(b);
     u32 len = read_beu32(b);
-    memcpy(dest, buffer_ref(b, 0), len);
+
+    struct nfs4_read_data *read_data = (struct nfs4_read_data*) dest;
+    read_data->eof = eof;
+    read_data->len = len;
+
+    memcpy(read_data->dest, buffer_ref(b, 0), len);
     // assumes ordering
 
     // data is padded into multiple of 4

--- a/sfs/sfs.py
+++ b/sfs/sfs.py
@@ -251,7 +251,7 @@ class FileObjectWrapper(io.RawIOBase):
                 raise io.UnsupportedOperation("not readable") 
             print("Failed to read file: " + c_helper.nfs4_error_string(client).decode(encoding='utf-8'))
             return
-        self._pos += len(buffer.value)
+        self._pos += bytes_read
         return buffer.value
 
     def readall(self):

--- a/sfs/sfs.py
+++ b/sfs/sfs.py
@@ -244,9 +244,7 @@ class FileObjectWrapper(io.RawIOBase):
             return self.readall()
         elif size < 0:
             raise ValueError("size must be >= -1")
-        buf = ctypes.cast(
-                ctypes.create_string_buffer(size),
-                ctypes.POINTER(ctypes.c_char))
+        buf = ctypes.create_string_buffer(size)
         bytes_read = c_helper.nfs4_pread(self._file, buf, self._pos, size)
         if bytes_read < 0:
             if c_helper.nfs4_error_num(client) == NFS4ERR_OPENMODE:


### PR DESCRIPTION
Edit `nfs4_pread` to send a struct pointer rather than a buffer pointer. This pointer contains the original buffer, as well as information on the length of data written and EOF.

This fixes the reading of binary files that contain `\0`.